### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add package.json
           git commit -m "Release: bump version to ${{ steps.bump_version.outputs.VERSION }}"
-          git push
+          git push -f
 
       # Create changelog
       - name: Create changelog from commits


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Without a service account I needed to force the push within the workflow. This also means that any developer with permissions to push to this repo could also force push. I don't see this being an issue as we all know not to force push. In the future we could get a service account to handle this or maybe GitHub will improve their settings to allow for this.


## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
