### PR TITLE
UTOPIA-1580: Changed highlighter from p to span

### DIFF
--- a/src/Toolbar/Toolbar.tsx
+++ b/src/Toolbar/Toolbar.tsx
@@ -95,7 +95,7 @@ export const Toolbar = (props: ToolbarProps) => {
             contentRef,
             handleChange: () =>
               handleChange({ contentRef, content, setContent }),
-            tag: "P",
+            tag: "SPAN",
             className: "rt-yellowHighlight",
           })
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,8 @@ export type HTMLTag =
   | "P"
   | "LI"
   | "DIV"
-  | "A";
+  | "A"
+  | "SPAN";
 
 export type SelectionContext = {
   currentNode: Node | null;

--- a/src/utils/sanitizeContent.ts
+++ b/src/utils/sanitizeContent.ts
@@ -1,6 +1,19 @@
 export const sanitizeContent = (htmlContent: string): string => {
   // Define an allowlist of allowed tags
-  const allowlist = ["p", "br", "h", "ul", "ol", "li", "b", "i", "s", "u", "a"];
+  const allowlist = [
+    "p",
+    "br",
+    "h",
+    "ul",
+    "ol",
+    "li",
+    "b",
+    "i",
+    "s",
+    "u",
+    "a",
+    "span",
+  ];
 
   // Remove DOCTYPE, XML declarations, <link> tags, and inline styles
   htmlContent = htmlContent.replace(/<!DOCTYPE.*?>/gi, "");


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1580](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1580)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Fixed an issue where highlighted text would be placed on a newline because it was a p tag within another p tag, which is not allowed. Fixed by changing element to a span.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
