### PR TITLE
Fix icon styling size in DPIA

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-.rt-container, .rt-toolbar, .rt-content, .rt-button, ::after, ::before {
+.rt-container, .rt-toolbar, .rt-content, .rt-button, .rt-icon, ::after, ::before {
   box-sizing: content-box;
 }
 


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
DPIA uses a style that makes icons in the toolbar smaller than intended. This change prevents this.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
